### PR TITLE
Added options to slot_data + new patch to skip Bonus Rings

### DIFF
--- a/worlds/yoshisisland/Options.py
+++ b/worlds/yoshisisland/Options.py
@@ -52,6 +52,10 @@ class DisableAutoScrollers(Toggle):
     """If enabled, will disable autoscrolling during levels, except during levels which cannot function otherwise."""
     display_name = "Disable Autoscrolling"
 
+class SkipBonusRing(Toggle):
+    """Skips the bonus ring animation at the end of levels and disables the end of level bonuses."""
+    display_name = "Skip Bonus Ring"
+
 class ItemLogic(Toggle):
     """This will enable logic to expect consumables to be used from the inventory in place of some major items.
     Logic will expect you to have access to an Overworld bonus game, or a bandit game to get the necessary items.
@@ -257,6 +261,7 @@ class YoshisIslandOptions(PerGameCommonOptions):
     stage_logic: StageLogic
     item_logic: ItemLogic
     disable_autoscroll: DisableAutoScrollers
+    skip_bonus_ring: SkipBonusRing
     softlock_prevention: SoftlockPrevention
     castle_open_condition: FinalLevelBosses
     castle_clear_condition: FinalBossBosses

--- a/worlds/yoshisisland/Options.py
+++ b/worlds/yoshisisland/Options.py
@@ -52,9 +52,14 @@ class DisableAutoScrollers(Toggle):
     """If enabled, will disable autoscrolling during levels, except during levels which cannot function otherwise."""
     display_name = "Disable Autoscrolling"
 
-class SkipBonusRing(Toggle):
-    """Skips the bonus ring animation at the end of levels and disables the end of level bonuses."""
+class SkipBonusRing(Choice):
+    """Skips the bonus ring animation at the end of levels and disables the end of level bonuses.
+    The faster version also skips the high score screen."""
     display_name = "Skip Bonus Ring"
+    option_none = 0
+    option_normal = 1
+    option_fast = 2
+    default = 0
 
 class ItemLogic(Toggle):
     """This will enable logic to expect consumables to be used from the inventory in place of some major items.

--- a/worlds/yoshisisland/Rom.py
+++ b/worlds/yoshisisland/Rom.py
@@ -1023,6 +1023,11 @@ def ExtendedItemHandler(rom):
     rom.write_bytes(0x10B430, bytearray([0xD0, 0xF7, 0xA9, 0x01, 0x8D, 0xB6, 0x14, 0xA9, 0x0A, 0x8D, 0x18, 0x02, 0xA9, 0x16, 0x8D, 0x18]))
     rom.write_bytes(0x10B440, bytearray([0x01, 0xA9, 0x97, 0x8D, 0x53, 0x00, 0x5C, 0x0A, 0xF5, 0x0B, 0xFA, 0x5C, 0x10, 0xF5, 0x0B]))
 
+def PatchBonusRing(rom):
+    rom.write_bytes(0x127CF, bytearray([0x60, 0x04]))       # SBC #$0460 Subtract larger number from ring animation counter each frame
+    rom.write_bytes(0x12815, bytearray([0xA9, 0x00, 0x00])) # LDA #$0000 Force no bonus
+    rom.write_bytes(0x12898, bytearray([0xA9, 0x00, 0x00])) # LDA #$0000 Force no bonus
+    rom.write_bytes(0x12BF0, bytearray([0xA9, 0x90, 0x00])) # LDA #$0090 Speed up timer for yoshi exiting the stage
 
 def patch_rom(world, rom, player: int, multiworld):
     handle_items(rom) #Implement main item functionality
@@ -1166,7 +1171,10 @@ def patch_rom(world, rom, player: int, multiworld):
 
     if world.options.softlock_prevention == 1:
         rom.write_bytes(0x00C18F, bytearray([0x5C, 0x58, 0xFB, 0x0B])) #R + X Code
-
+    
+    if world.options.skip_bonus_ring == 1:
+        PatchBonusRing(rom)
+    
     if world.options.bowser_door_mode.value != 0:
         rom.write_bytes(0x07891F, bytearray(world.castle_door)) #1 Entry
         rom.write_bytes(0x078923, bytearray(world.castle_door)) #2 Entry

--- a/worlds/yoshisisland/__init__.py
+++ b/worlds/yoshisisland/__init__.py
@@ -12,7 +12,7 @@ import settings
 from .Items import get_item_names_per_category, item_table, filler_items, trap_items
 from .Locations import get_locations
 from .Regions import create_regions
-from .Options import YoshisIslandOptions
+from .Options import YoshisIslandOptions, Toggle
 from .setup_game import setup_gamevars
 from .Client import YISNIClient
 from .Rules import set_easy_rules, set_normal_rules, set_hard_rules
@@ -89,7 +89,7 @@ class YIWorld(World):
         if not os.path.exists(rom_file):
             raise FileNotFoundError(rom_file)
 
-    def fill_slot_data(self):
+    def _get_slot_data(self):
         return {
             "world_1": self.world_1_stages,
             "world_2": self.world_2_stages,
@@ -98,6 +98,14 @@ class YIWorld(World):
             "world_5": self.world_5_stages,
             "world_6": self.world_6_stages
         }
+    
+    def fill_slot_data(self) -> dict:
+        slot_data = self._get_slot_data()
+        for option_name in (attr.name for attr in dataclasses.fields(YoshisIslandOptions)
+           if attr not in dataclasses.fields(PerGameCommonOptions)):
+           option = getattr(self.options, option_name)
+           slot_data[option_name] = bool(option.value) if isinstance(option, Toggle) else option.value
+        return slot_data
 
     def write_spoiler_header(self, spoiler_handle: TextIO) -> None:
         spoiler_handle.write(f"Burt The Bashful's Boss Door:      {self.boss_order[0]}\n")


### PR DESCRIPTION
## What is this fixing or adding?
- Slot_data now gets filled with options for autotracking.
- Added a new option that turns off the end of level bonuses.

## How was this tested?
- Generated new world and tested level end.
- Checked if correct levels get autotracked in PopTracker.

## If this makes graphical changes, please attach screenshots.
