### PR TITLE
cv_dos: Fix missing parens for Abyss

### DIFF
--- a/worlds/cv_dos/Regions.py
+++ b/worlds/cv_dos/Regions.py
@@ -345,7 +345,7 @@ def init_areas(world: "DoSWorld", locations: List[LocationData]) -> None:
     #Mine of Judgment
     if world.mine_status != "Disabled":
         multiworld.get_region("Mine of Judgment", player).add_exits(["The Abyss", "Warp Room"],
-                                                                    {"The Abyss": lambda state: state.has_any(small_uppies, player) or state.has("Pupper Master Soul", player) and state.has(world.magic_seal_table["Mine of Judgment"], player)})
+                                                                    {"The Abyss": lambda state: (state.has_any(small_uppies, player) or state.has("Pupper Master Soul", player)) and state.has(world.magic_seal_table["Mine of Judgment"], player)})
 
         multiworld.get_region("The Abyss", player).add_exits(["Mine of Judgment", "The Abyss Beyond Abaddon"],
                                                             {"Mine of Judgment": lambda state: state.has_any(small_uppies, player),


### PR DESCRIPTION
## What is this fixing or adding?
Played a seed where a friend's Magic Seal 5 was found in a sphere _after_ The Abyss: Sand Area. Poked around in the logic, and spotted the presumed bug.

Disclaimer: I don't know DoS at all. I'm just going off of the friend's description of the game's access requirements.

## How was this tested?
Nope

## If this makes graphical changes, please attach screenshots.
Nah