### PR TITLE
[Melee] Fix rules for some bonuses

### DIFF
--- a/worlds/melee/Rules.py
+++ b/worlds/melee/Rules.py
@@ -293,7 +293,7 @@ def set_location_rules(world: "SSBMWorld") -> None:
         set_rule(world.get_location("Bonus - Gourmet"), Has("Food"))
         set_rule(world.get_location("Bonus - Battering Ram"), HasAny("Lip's Stick", "Star Rod", "Beam Sword", "Home-Run Bat", "Fan", "Hammer"))
         set_rule(world.get_location("Bonus - Straight Shooter"), HasAny(*projectile_item))
-        set_rule(world.get_location("Bonus - Wimp"), HasAny("Food", "Maxim Tomato", "Heart Container"))
+        set_rule(world.get_location("Bonus - Wimp"), Has("Heart Container"))
         set_rule(world.get_location("Bonus - Shape-Shifter"), HasAny("Super Mushroom", "Poison Mushroom", "Metal Box", "Cloaking Device", "Bunny Hood"))
         set_rule(world.get_location("Bonus - Chuck Wagon"), HasAny("Mr. Saturn", "Capsule", "Poké Ball", "Green Shell", "Red Shell", "Freezie", "Bob-omb", "Motion-Sensor Bomb", "Barrel", "Crate"))
         set_rule(world.get_location("Bonus - Parasol Finish"), Has("Parasol"))
@@ -325,6 +325,8 @@ def set_location_rules(world: "SSBMWorld") -> None:
         set_rule(world.get_location("Bonus - Headless Hammer"), Has("Hammer"))
         set_rule(world.get_location("Bonus - Bob-omb's Away"), Has("Bob-omb"))
         set_rule(world.get_location("Bonus - Bob-omb Squad"), Has("Bob-omb"))
+        set_rule(world.get_location("Bonus - Laser Marksman"), Has("Ray Gun"))
+        set_rule(world.get_location("Bonus - Pokémon KO"), Has("Poké Ball"))
         
         if world.options.enable_rare_pokemon_checks:
             set_rule(world.get_location("Bonus - Mew Catcher"), Has("Poké Ball"))


### PR DESCRIPTION
## What is this fixing or adding?
Fixes the following bonuses
- Bonus - Laser Marksman - Hit with every blast from a Ray Gun.
  - Require Ray Gun for this bonus
- Bonus - Pokémon KO - KO'd a foe with a Poké Ball Pokémon.
  - Require Poké Ball for this bonus
- Bonus - Wimp - Used only recovery items (3 or more).
  - Update to only require Heart Container for this bonus
  - https://retroachievements.org/achievement/434718
    - From Leviathan01: `Heads up before anyone wastes time like I did. Food and Maximum Tomatoes are not considered "Recovery Items" for the purposes of the "Wimp" bonus. Only the Heart Container is.`

## How was this tested?
Loaded the apworld in Universal Tracker and the impossible bonuses went away. This was tested on a seed that did not get the Poke Ball or Ray Gun items yet. It also had Maxim Tomatoes but no Food or Heart Containers

Before:
<img width="804" height="632" alt="before" src="https://github.com/user-attachments/assets/4358e514-01e3-463d-818e-63bb294e82cd" />

After:
<img width="801" height="628" alt="after" src="https://github.com/user-attachments/assets/742850dd-4e50-435c-99af-b95325469422" />

## If this makes graphical changes, please attach screenshots.
N/A