### PR TITLE
Fix Bonus - Super Spy

### DIFF
--- a/worlds/melee/Rules.py
+++ b/worlds/melee/Rules.py
@@ -327,6 +327,7 @@ def set_location_rules(world: "SSBMWorld") -> None:
         set_rule(world.get_location("Bonus - Bob-omb Squad"), Has("Bob-omb"))
         set_rule(world.get_location("Bonus - Laser Marksman"), Has("Ray Gun"))
         set_rule(world.get_location("Bonus - Pokémon KO"), Has("Poké Ball"))
+        set_rule(world.get_location("Bonus - Super Spy"), Has("Motion-Sensor Bomb"))
         
         if world.options.enable_rare_pokemon_checks:
             set_rule(world.get_location("Bonus - Mew Catcher"), Has("Poké Ball"))


### PR DESCRIPTION
## What is this fixing or adding?
Add a condition for `Bonus - Super Spy` to require `Motion-Sensor Bomb`

From https://www.ssbwiki.com/List_of_bonuses#Super_Smash_Bros._Melee
- Super Spy - KO'd someone with a Motion-Sensor Bomb.

## How was this tested?
This was tested with a fresh multiworld without any items sent to the melee slot

Before - 2.0.1 apworld shows Bonus - Super Spy in UT
<img width="531" height="509" alt="melee-super-spy-before" src="https://github.com/user-attachments/assets/cbd0a106-d423-4ec6-bb06-529483eeb844" />

After - fixed apworld does not show Bonus - Super Spy in UT
<img width="378" height="380" alt="melee-super-spy-after" src="https://github.com/user-attachments/assets/36731a07-1057-492d-83a6-d60b544c2317" />

## If this makes graphical changes, please attach screenshots.
N/A