### PR TITLE
CV PoR: Fix non-deterministic generation caused by using sets

### DIFF
--- a/worlds/cv_por/generator_main.py
+++ b/worlds/cv_por/generator_main.py
@@ -47,6 +47,8 @@ def generate_early(world) -> None:
         world.portrait_connections["Nest of Evil"] = passthrough["passage_portrait"]
     setup_game(world)
     world.auth_id = world.random.getrandbits(32)
+    world.important_quests = sorted(world.important_quests)
+    world.quest_requirements = sorted(world.quest_requirements)
 
 
 def create_regions(world) -> None:

--- a/worlds/cv_por/modules/quest_data.py
+++ b/worlds/cv_por/modules/quest_data.py
@@ -158,6 +158,8 @@ def setup_quests(world):
     if "grindy" in selected_quests:
         selected_quests |= grindy_quests
 
+    selected_quests = sorted(selected_quests)
+
     for quest in quest_data:
         if quest.casefold() in selected_quests or quest.split(": ")[1].casefold() in selected_quests or quest in selected_quests:
             world.active_quests.append(quest)
@@ -200,6 +202,8 @@ def setup_quests(world):
     
     #  Filter any inactive quests out of exclusions.
     excluded_quests = {quest for quest in excluded_quests if quest in world.active_quests}
+
+    excluded_quests = sorted(excluded_quests)
 
     for quest in excluded_quests:
         if quest in world.active_quests:


### PR DESCRIPTION
## What is this fixing or adding?
This PR fixes the non-deterministic generation caused by iterating over sets before they are sorted.
`selected_quests`, `excluded_quests`, `important_quests`, and `quest_requirements` were unsorted, which was causing generation that was non-deterministic (using the same initial seed twice would not result in the same final multiworld). The fastest (and simplest) way to fix the problem was to sort them before they are iterated upon. In a test of 1,000 generations, the changes from this PR increased gen time by ~1.6ms per generation. 

## How was this tested?
I ran all unit tests and none failed. I used the APWorld Fuzzer to ensure there was no regression in generation failure rates. I used the Fuzzer's provided determinism hook, which always passed with these changes. Before, the hook would always fail with any amount of quest randomization on.

## If this makes graphical changes, please attach screenshots.
N/A